### PR TITLE
Fix cnn input to feed-forward network

### DIFF
--- a/04__convolutional_neural_networks/cifar_cnn.py
+++ b/04__convolutional_neural_networks/cifar_cnn.py
@@ -149,7 +149,7 @@ def build_second_net():
     conv3_flat = tf.reshape(conv3_pool, [-1, C3])
     conv3_drop = tf.nn.dropout(conv3_flat, keep_prob=keep_prob)
 
-    full1 = tf.nn.relu(full_layer(conv3_flat, F1))
+    full1 = tf.nn.relu(full_layer(conv3_drop, F1))
     full1_drop = tf.nn.dropout(full1, keep_prob=keep_prob)
 
     y_conv = full_layer(full1_drop, 10)


### PR DESCRIPTION
On the **build_second_net** method, the layer being passed to the fully connected network is the **conv3_flat** instead of the **conv3_drop**. This MR solves that.